### PR TITLE
Change status bar color based on theme mode

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:device_frame/device_frame.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:primer_progress_bar/primer_progress_bar.dart';
 
 void main() {
@@ -27,12 +28,17 @@ class MyApp extends StatelessWidget {
     return ValueListenableBuilder(
       valueListenable: themeMode,
       builder: (context, brightness, _) {
-        return MaterialApp(
-          theme: ThemeData(
-            useMaterial3: true,
-            brightness: brightness,
+        return AnnotatedRegion(
+          value: brightness == Brightness.light
+              ? SystemUiOverlayStyle.dark
+              : SystemUiOverlayStyle.light,
+          child: MaterialApp(
+            theme: ThemeData(
+              useMaterial3: true,
+              brightness: brightness,
+            ),
+            home: home,
           ),
-          home: home,
         );
       },
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:device_frame/device_frame.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -187,22 +189,42 @@ class _HomeState extends State<Home> {
       ),
     );
 
+    final body = Padding(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        children: [
+          Expanded(
+            child: Center(
+              child: progressBar,
+            ),
+          ),
+          options,
+        ],
+      ),
+    );
+
+    const minBodyHeight = 400.0;
+    final bodyContainer = LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              minHeight: minBodyHeight,
+              maxHeight: max(
+                constraints.maxHeight,
+                minBodyHeight,
+              ),
+            ),
+            child: body,
+          ),
+        );
+      },
+    );
+
     return Scaffold(
       appBar: AppBar(),
       extendBodyBehindAppBar: true,
-      body: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Column(
-          children: [
-            Expanded(
-              child: Center(
-                child: progressBar,
-              ),
-            ),
-            options,
-          ],
-        ),
-      ),
+      body: bodyContainer,
       bottomNavigationBar: BottomAppBar(
         child: slider,
       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -143,34 +143,31 @@ class _HomeState extends State<Home> {
       },
     );
 
-    final options = Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        SwitchListTile(
-          title: const Text("Dark Theme"),
-          value: themeMode.value == Brightness.dark,
-          onChanged: (turnedOn) {
-            setState(() {
-              themeMode.value = turnedOn ? Brightness.dark : Brightness.light;
-            });
-          },
-        ),
-        SwitchListTile(
-          title: const Text("Always fill the entier bar"),
-          value: alwaysFillBar,
-          onChanged: (turnedOn) {
-            setState(() => alwaysFillBar = turnedOn);
-          },
-        ),
-        SwitchListTile(
-          title: const Text("Limit the legend lines"),
-          value: limitLegendLines,
-          onChanged: (turnedOn) {
-            setState(() => limitLegendLines = turnedOn);
-          },
-        ),
-      ],
-    );
+    final options = [
+      SwitchListTile(
+        title: const Text("Dark Theme"),
+        value: themeMode.value == Brightness.dark,
+        onChanged: (turnedOn) {
+          setState(() {
+            themeMode.value = turnedOn ? Brightness.dark : Brightness.light;
+          });
+        },
+      ),
+      SwitchListTile(
+        title: const Text("Always fill the entier bar"),
+        value: alwaysFillBar,
+        onChanged: (turnedOn) {
+          setState(() => alwaysFillBar = turnedOn);
+        },
+      ),
+      SwitchListTile(
+        title: const Text("Limit the legend lines"),
+        value: limitLegendLines,
+        onChanged: (turnedOn) {
+          setState(() => limitLegendLines = turnedOn);
+        },
+      ),
+    ];
 
     final slider = SizedBox(
       height: 56,
@@ -198,7 +195,7 @@ class _HomeState extends State<Home> {
               child: progressBar,
             ),
           ),
-          options,
+          ...options,
         ],
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:device_frame/device_frame.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:primer_progress_bar/primer_progress_bar.dart';
 
 void main() {
@@ -28,17 +27,12 @@ class MyApp extends StatelessWidget {
     return ValueListenableBuilder(
       valueListenable: themeMode,
       builder: (context, brightness, _) {
-        return AnnotatedRegion(
-          value: brightness == Brightness.light
-              ? SystemUiOverlayStyle.dark
-              : SystemUiOverlayStyle.light,
-          child: MaterialApp(
-            theme: ThemeData(
-              useMaterial3: true,
-              brightness: brightness,
-            ),
-            home: home,
+        return MaterialApp(
+          theme: ThemeData(
+            useMaterial3: true,
+            brightness: brightness,
           ),
+          home: home,
         );
       },
     );
@@ -194,6 +188,8 @@ class _HomeState extends State<Home> {
     );
 
     return Scaffold(
+      appBar: AppBar(),
+      extendBodyBehindAppBar: true,
       body: Padding(
         padding: const EdgeInsets.all(20),
         child: Column(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -221,7 +221,11 @@ class _HomeState extends State<Home> {
     return Scaffold(
       appBar: AppBar(),
       extendBodyBehindAppBar: true,
-      body: bodyContainer,
+      body: SafeArea(
+        top: false,
+        bottom: false,
+        child: bodyContainer,
+      ),
       bottomNavigationBar: BottomAppBar(
         child: slider,
       ),


### PR DESCRIPTION
Previously, the status bar text color would remain black in dark mode, making it difficult to read against the dark background. This commit adds a new feature that changes the status bar text color to white in dark mode and black in light mode, ensuring that it is visible and easy to read.

To achieve this, the `SystemUiOverlayStyle` is set dynamically based on the `brightness` value. The `AnnotatedRegion` widget is used to apply the `SystemUiOverlayStyle` to the entire app, including the status bar.
![ControlRoom-2023-07-03-11-18-21_AdobeExpress](https://github.com/fujidaiti/primer_progress_bar/assets/81863556/28bdcd08-3b5e-4b2f-95e5-2e3533453ab8)
