### PR TITLE
Add showLegend Attribute to Toggle Legend Visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.5.0 August 16, 2024
+
+- Add: `showLegend` Attribute to Toggle Legend Visibility (#24)
+
 ## 0.4.2 May 18, 2024
 
 Dependency updates.

--- a/lib/src/primer_progress_bar.dart
+++ b/lib/src/primer_progress_bar.dart
@@ -26,6 +26,7 @@ class PrimerProgressBar extends StatelessWidget {
     this.barStyle = const SegmentedBarStyle(),
     this.legendStyle = const SegmentedBarLegendStyle(),
     this.legendItemBuilder = _defaultLegendItemBuilder,
+    this.showLegend = true,
   }) : assert(maxTotalValue == null || maxTotalValue > 0);
 
   /// A list of [Segment] to be displayed in the progress bar.
@@ -46,11 +47,16 @@ class PrimerProgressBar extends StatelessWidget {
   /// A builder that creates a [LegendItems] from a [Segment] for the legend.
   final LegendItemBuilder legendItemBuilder;
 
+  /// Whether to display the legend.
+  ///
+  /// If `true`, the legend will be shown. If `false`, the legend will be hidden.
+  final bool showLegend;
+
   @override
   Widget build(BuildContext context) {
     final legendItems = segments.map(legendItemBuilder).toList();
     if (legendStyle.maxLines == null) {
-      return _build(context, segments, legendItems);
+      return _build(context, segments, legendItems, showLegend);
     }
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -69,16 +75,13 @@ class PrimerProgressBar extends StatelessWidget {
         final segments = [
           for (final item in ellipsizedLegendItems) item.segment
         ];
-        return _build(context, segments, ellipsizedLegendItems);
+        return _build(context, segments, ellipsizedLegendItems, showLegend);
       },
     );
   }
 
-  Widget _build(
-    BuildContext context,
-    List<Segment> segments,
-    List<LegendItem> legendItems,
-  ) {
+  Widget _build(BuildContext context, List<Segment> segments,
+      List<LegendItem> legendItems, bool showLegend) {
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -88,16 +91,17 @@ class PrimerProgressBar extends StatelessWidget {
           style: barStyle,
           maxTotalValue: maxTotalValue,
         ),
-        SegmentedBarLegend(
-          style: SegmentedBarLegendStyle(
-            maxLines: null,
-            spacing: legendStyle.spacing,
-            runSpacing: legendStyle.runSpacing,
-            padding: legendStyle.padding,
+        if (showLegend)
+          SegmentedBarLegend(
+            style: SegmentedBarLegendStyle(
+              maxLines: null,
+              spacing: legendStyle.spacing,
+              runSpacing: legendStyle.runSpacing,
+              padding: legendStyle.padding,
+            ),
+            ellipsisBuilder: legendEllipsisBuilder,
+            children: legendItems,
           ),
-          ellipsisBuilder: legendEllipsisBuilder,
-          children: legendItems,
-        ),
       ],
     );
   }

--- a/lib/src/primer_progress_bar.dart
+++ b/lib/src/primer_progress_bar.dart
@@ -82,16 +82,16 @@ class PrimerProgressBar extends StatelessWidget {
 
   Widget _build(BuildContext context, List<Segment> segments,
       List<LegendItem> legendItems, bool showLegend) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        SegmentedBar(
-          segments: segments,
-          style: barStyle,
-          maxTotalValue: maxTotalValue,
-        ),
-        if (showLegend)
+    if (showLegend) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SegmentedBar(
+            segments: segments,
+            style: barStyle,
+            maxTotalValue: maxTotalValue,
+          ),
           SegmentedBarLegend(
             style: SegmentedBarLegendStyle(
               maxLines: null,
@@ -102,7 +102,14 @@ class PrimerProgressBar extends StatelessWidget {
             ellipsisBuilder: legendEllipsisBuilder,
             children: legendItems,
           ),
-      ],
+        ],
+      );
+    }
+
+    return SegmentedBar(
+      segments: segments,
+      style: barStyle,
+      maxTotalValue: maxTotalValue,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: primer_progress_bar
 description: Unofficial Flutter implementation of the progress bar defined in GitHub Primer Design System.
-version: 0.4.2
+version: 0.5.0
 repository: https://github.com/fujidaiti/primer_progress_bar
 
 environment:


### PR DESCRIPTION
This pull request introduces a new boolean attribute showLegend to the chart component. The showLegend attribute allows users to control the visibility of the legend. When set to true, the legend will be displayed; when set to false, the legend will be hidden. This enhancement provides greater flexibility for users to customize the appearance of their charts based on their specific requirements.